### PR TITLE
[t-1] Create genre cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,9 +109,14 @@
             <version>2.5.0</version>
         </dependency>
 
+        <!-- yaml properties -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.23</version>
+        </dependency>
 
         <!-- Test-->
-
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>

--- a/src/main/java/com/pasechnik/movieland/dao/cache/CachedGenreDao.java
+++ b/src/main/java/com/pasechnik/movieland/dao/cache/CachedGenreDao.java
@@ -28,13 +28,12 @@ public class CachedGenreDao implements GenreDao {
 
     @Override
     public List<Genre> getAll() {
-        logger.debug("GetAll from CachedGenreDao");
         return new ArrayList<>(cache);
     }
 
     @PostConstruct
     @Scheduled(initialDelayString = "${schedule.initial_delay_time}", fixedDelayString = "${schedule.fixed_delay_time}")
-    public void refreshCache() {
+    private void refreshCache() {
         cache = genreDao.getAll();
         logger.debug("Refresh for cache was completed, size {} rows", cache.size());
     }

--- a/src/main/java/com/pasechnik/movieland/dao/cache/CachedGenreDao.java
+++ b/src/main/java/com/pasechnik/movieland/dao/cache/CachedGenreDao.java
@@ -1,0 +1,41 @@
+package com.pasechnik.movieland.dao.cache;
+
+import com.pasechnik.movieland.dao.GenreDao;
+import com.pasechnik.movieland.entity.Genre;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Repository;
+
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+
+@Primary
+@Repository
+public class CachedGenreDao implements GenreDao {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private volatile List<Genre> cache;
+    private GenreDao genreDao;
+
+    @Autowired
+    public CachedGenreDao(@Qualifier("jdbcGenreDao") GenreDao genreDao) {
+        this.genreDao = genreDao;
+    }
+
+    @Override
+    public List<Genre> getAll() {
+        logger.debug("GetAll from CachedGenreDao");
+        return new ArrayList<>(cache);
+    }
+
+    @PostConstruct
+    @Scheduled(initialDelayString = "${schedule.initial_delay_time}", fixedDelayString = "${schedule.fixed_delay_time}")
+    public void refreshCache() {
+        cache = genreDao.getAll();
+        logger.debug("Refresh for cache was completed, size {} rows", cache.size());
+    }
+}

--- a/src/main/java/com/pasechnik/movieland/dao/jdbc/JdbcGenreDao.java
+++ b/src/main/java/com/pasechnik/movieland/dao/jdbc/JdbcGenreDao.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository("jdbcGenreDao")
+@Repository
 public class JdbcGenreDao implements GenreDao {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private static final GenreRowMapper GENRE_ROW_MAPPER = new GenreRowMapper();
@@ -20,7 +20,6 @@ public class JdbcGenreDao implements GenreDao {
 
     @Override
     public List<Genre> getAll() {
-        logger.debug("GetAll from JdbcGenreDao");
         return jdbcTemplate.query(getAllGenresSQL,GENRE_ROW_MAPPER);
     }
 

--- a/src/main/java/com/pasechnik/movieland/dao/jdbc/JdbcGenreDao.java
+++ b/src/main/java/com/pasechnik/movieland/dao/jdbc/JdbcGenreDao.java
@@ -3,21 +3,24 @@ package com.pasechnik.movieland.dao.jdbc;
 import com.pasechnik.movieland.dao.GenreDao;
 import com.pasechnik.movieland.dao.jdbc.mapper.GenreRowMapper;
 import com.pasechnik.movieland.entity.Genre;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
+@Repository("jdbcGenreDao")
 public class JdbcGenreDao implements GenreDao {
-
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private static final GenreRowMapper GENRE_ROW_MAPPER = new GenreRowMapper();
     private JdbcTemplate jdbcTemplate;
     private String getAllGenresSQL;
 
     @Override
     public List<Genre> getAll() {
+        logger.debug("GetAll from JdbcGenreDao");
         return jdbcTemplate.query(getAllGenresSQL,GENRE_ROW_MAPPER);
     }
 

--- a/src/main/java/com/pasechnik/movieland/dao/jdbc/mapper/GenreRowMapper.java
+++ b/src/main/java/com/pasechnik/movieland/dao/jdbc/mapper/GenreRowMapper.java
@@ -9,9 +9,9 @@ import java.sql.SQLException;
 public class GenreRowMapper implements RowMapper<Genre> {
     @Override
     public Genre mapRow(ResultSet resultSet, int i) throws SQLException {
-        Genre genre = new Genre();
-        genre.setId(resultSet.getInt("id"));
-        genre.setName(resultSet.getString("genre"));
+        int id = resultSet.getInt("id");
+        String name = resultSet.getString("genre");
+        Genre genre = new Genre(id, name);
         return genre;
     }
 }

--- a/src/main/java/com/pasechnik/movieland/entity/Genre.java
+++ b/src/main/java/com/pasechnik/movieland/entity/Genre.java
@@ -6,20 +6,17 @@ public class Genre {
     private int id;
     private String name;
 
+    public Genre(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
     public int getId() {
         return id;
     }
 
-    public void setId(int id) {
-        this.id = id;
-    }
-
     public String getName() {
         return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 
     @Override

--- a/src/main/resources/db/application.properties
+++ b/src/main/resources/db/application.properties
@@ -4,3 +4,5 @@ datasource.username=postgres
 datasource.password=Pasechnik
 datasource.dbcp2.max-total=20
 datasource.dbcp2.max-wait-millis=1000
+fixedDelayTime=14400000
+initialDelayTime=14400000

--- a/src/main/resources/db/application.properties
+++ b/src/main/resources/db/application.properties
@@ -1,8 +1,0 @@
-datasource.driver=org.postgresql.Driver
-datasource.url=jdbc:postgresql://localhost:5432/postgres
-datasource.username=postgres
-datasource.password=Pasechnik
-datasource.dbcp2.max-total=20
-datasource.dbcp2.max-wait-millis=1000
-fixedDelayTime=14400000
-initialDelayTime=14400000

--- a/src/main/resources/db/application.yml
+++ b/src/main/resources/db/application.yml
@@ -1,0 +1,11 @@
+jdbc:
+  driver : org.postgresql.Driver
+  url : jdbc:postgresql://localhost:5432/postgres
+  username : postgres
+  password : Pasechnik
+dbcp2:
+    max_total : 20
+    max_wait_millis : 1000
+schedule:
+  fixed_delay_time : 14400000
+  initial_delay_time : 14400000

--- a/src/main/resources/spring/root-context.xml
+++ b/src/main/resources/spring/root-context.xml
@@ -2,29 +2,38 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:task="http://www.springframework.org/schema/task"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context.xsd  ">
+        http://www.springframework.org/schema/context/spring-context.xsd
+http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
 
     <import resource="query-context.xml"/>
-    <context:property-placeholder location="classpath:/db/application.properties" />
+   <!-- <context:property-placeholder location="classpath:/db/application.properties" />-->
+
+    <bean id="yamlProperties" class="org.springframework.beans.factory.config.YamlPropertiesFactoryBean">
+        <property name="resources" value="classpath:/db/application.yml"/>
+    </bean>
+
+    <context:property-placeholder properties-ref="yamlProperties"/>
 
     <context:component-scan base-package="com.pasechnik.movieland">
         <context:exclude-filter type="regex" expression="com\.pasechnik\.movieland\.controller\..*"/>
     </context:component-scan>
 
+    <task:annotation-driven/>
     <bean id="jdbcTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
         <property name="dataSource" ref="dataSource"/>
     </bean>
 
     <bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource"
           destroy-method="close">
-        <property name="driverClassName" value="${datasource.driver}" />
-        <property name="url" value="${datasource.url}" />
-        <property name="username" value="${datasource.username}" />
-        <property name="password" value="${datasource.password}" />
-        <property name="maxWaitMillis" value="${datasource.dbcp2.max-wait-millis}" />
-        <property name="maxTotal" value="${datasource.dbcp2.max-total}" />
+        <property name="driverClassName" value="${jdbc.driver}" />
+        <property name="url" value="${jdbc.url}" />
+        <property name="username" value="${jdbc.username}" />
+        <property name="password" value="${jdbc.password}" />
+        <property name="maxWaitMillis" value="${dbcp2.max_wait_millis}" />
+        <property name="maxTotal" value="${dbcp2.max_total}" />
     </bean>
 </beans>

--- a/src/main/resources/spring/root-context.xml
+++ b/src/main/resources/spring/root-context.xml
@@ -10,7 +10,6 @@
 http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
 
     <import resource="query-context.xml"/>
-   <!-- <context:property-placeholder location="classpath:/db/application.properties" />-->
 
     <bean id="yamlProperties" class="org.springframework.beans.factory.config.YamlPropertiesFactoryBean">
         <property name="resources" value="classpath:/db/application.yml"/>

--- a/src/test/java/com/pasechnik/movieland/controller/GenreControllerTestI.java
+++ b/src/test/java/com/pasechnik/movieland/controller/GenreControllerTestI.java
@@ -57,9 +57,7 @@ public class GenreControllerTestI extends AbstractJUnit4SpringContextTests {
 
     @Test
     public void testGetAll() throws Exception {
-        Genre genre = new Genre();
-        genre.setId(1);
-        genre.setName("драма");
+        Genre genre = new Genre(1, "драма");
 
         // When
         when(genreService.getAll()).thenReturn(Collections.singletonList(genre));

--- a/src/test/java/com/pasechnik/movieland/dao/cache/CacheGenreDaoTest.java
+++ b/src/test/java/com/pasechnik/movieland/dao/cache/CacheGenreDaoTest.java
@@ -1,12 +1,10 @@
-
-package com.pasechnik.movieland.dao.jdbc;
+package com.pasechnik.movieland.dao.cache;
 
 import com.pasechnik.movieland.dao.GenreDao;
 import com.pasechnik.movieland.entity.Genre;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -19,18 +17,17 @@ import static org.junit.Assert.assertEquals;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"file:src/main/resources/spring/root-context.xml", "file:src/main/webapp/WEB-INF/movieland-servlet.xml", "classpath:/spring/test-context.xml"})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-public class JdbcGenreDaoTest {
+public class CacheGenreDaoTest {
 
     @Autowired
-    @Qualifier("jdbcGenreDao")
-    GenreDao jdbcGenreDao;
+    GenreDao cachedGenreDao;
 
     @Test
     public void testGetAll() {
 
         Genre expectedGenre = new Genre(1, "драма");
 
-        List<Genre> actualGenreList = jdbcGenreDao.getAll();
+        List<Genre> actualGenreList = cachedGenreDao.getAll();
         assertEquals(15, actualGenreList.size());
 
         int index = actualGenreList.indexOf(expectedGenre);

--- a/src/test/java/com/pasechnik/movieland/dao/jdbc/JdbcMovieDaoTest.java
+++ b/src/test/java/com/pasechnik/movieland/dao/jdbc/JdbcMovieDaoTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.*;
 @ContextConfiguration(locations = {"file:src/main/resources/spring/root-context.xml", "file:src/main/webapp/WEB-INF/movieland-servlet.xml", "classpath:/spring/test-context.xml"})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class JdbcMovieDaoTest {
+
     @Autowired
     private MovieDao movieDao;
 

--- a/src/test/java/com/pasechnik/movieland/service/DefaultGenreServiceTest.java
+++ b/src/test/java/com/pasechnik/movieland/service/DefaultGenreServiceTest.java
@@ -1,9 +1,7 @@
 package com.pasechnik.movieland.service;
 
 import com.pasechnik.movieland.dao.GenreDao;
-import com.pasechnik.movieland.dao.MovieDao;
 import com.pasechnik.movieland.entity.Genre;
-import com.pasechnik.movieland.entity.Movie;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -22,14 +20,10 @@ public class DefaultGenreServiceTest {
 
         List<Genre> expectedGenreList = new ArrayList<>();
 
-        Genre genre1 = new Genre();
-        genre1.setId(1);
-        genre1.setName("драма");
+        Genre genre1 = new Genre(1, "драма");
         expectedGenreList.add(genre1);
 
-        Genre genre2 = new Genre();
-        genre2.setId(2);
-        genre2.setName("криминал");
+        Genre genre2 = new Genre(2, "криминал");
         expectedGenreList.add(genre2);
 
         DefaultGenreService genreService = new DefaultGenreService(genreDao);


### PR DESCRIPTION
1.As list of genres is rather static, we can save time on DB calling. Instead of reading genres from DB, we will create genre cache to store them all.
2.In order to have relevant information, genre cache should be updated according to DB data each 4 hours.